### PR TITLE
Refactor/update golang versions1.19

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,5 +16,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.44
+          version: v1.50
           args: -E gosec,goconst,nestif,bodyclose,rowserrcheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.17]
+        go-version: [1.19]
     steps:
 
       - name: Set up Go  ${{ matrix.go-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.16, 1.17, 1.18]
+        go-version: [1.18, 1.19]
     steps:
 
       - name: Set up Go ${{ matrix.go-version }}

--- a/go.sum
+++ b/go.sum
@@ -16,14 +16,8 @@ github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYt
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 golang.org/x/crypto v0.0.0-20220321153916-2c7772ba3064 h1:S25/rfnfsMVgORT4/J61MJ7rdyseOZOyvLIrZEZ7s6s=
 golang.org/x/crypto v0.0.0-20220321153916-2c7772ba3064/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"crypto/sha512"
 
@@ -68,7 +67,7 @@ type openSSLPrivateKey struct {
 // Supported keys: OpenSSH (Ed25519), OpenSSL (Ed25519, X25519), Crypt4GH (X25519).
 func ReadPrivateKey(reader io.Reader, passPhrase []byte) (privateKey [chacha20poly1305.KeySize]byte, err error) {
 	var allBytes []byte
-	allBytes, err = ioutil.ReadAll(reader)
+	allBytes, err = io.ReadAll(reader)
 	if err != nil {
 		return
 	}
@@ -211,7 +210,7 @@ type openSSLPublicKey struct {
 // Supported keys: OpenSSH (Ed25519), OpenSSL (Ed25519, X25519), Crypt4GH (X25519).
 func ReadPublicKey(reader io.Reader) (publicKey [chacha20poly1305.KeySize]byte, err error) {
 	var allBytes []byte
-	allBytes, err = ioutil.ReadAll(reader)
+	allBytes, err = io.ReadAll(reader)
 	if err != nil {
 		return
 	}

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -200,7 +199,7 @@ func TestWriteOpenSSLX25519PrivateKey(t *testing.T) {
 	}
 	keyFile := strings.NewReader(ssl_x25519_sec)
 
-	keyFileBytes, err := ioutil.ReadAll(keyFile)
+	keyFileBytes, err := io.ReadAll(keyFile)
 	if err != nil {
 		t.Error(err)
 	}
@@ -221,7 +220,7 @@ func TestWriteOpenSSLX25519PublicKey(t *testing.T) {
 	}
 	keyFile := strings.NewReader(ssl_x25519_pub)
 
-	keyFileBytes, err := ioutil.ReadAll(keyFile)
+	keyFileBytes, err := io.ReadAll(keyFile)
 	if err != nil {
 		t.Error(err)
 	}
@@ -262,7 +261,7 @@ func TestWriteCrypt4GHX25519PublicKey(t *testing.T) {
 		t.Error(err)
 	}
 	keyFile := strings.NewReader(crypt4gh_x25519_pub)
-	keyFileBytes, err := ioutil.ReadAll(keyFile)
+	keyFileBytes, err := io.ReadAll(keyFile)
 	if err != nil {
 		t.Error(err)
 	}

--- a/streaming/streaming_test.go
+++ b/streaming/streaming_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -113,7 +112,7 @@ func TestReencryption(t *testing.T) {
 					t.Fail()
 				}
 			}
-			all, err := ioutil.ReadAll(reader)
+			all, err := io.ReadAll(reader)
 			if err != nil {
 				t.Error(err)
 			}
@@ -121,7 +120,7 @@ func TestReencryption(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			inBytes, err := ioutil.ReadAll(inFile)
+			inBytes, err := io.ReadAll(inFile)
 			if err != nil {
 				t.Error(err)
 			}
@@ -181,7 +180,7 @@ func TestReencryptionWithDataEditListInCrypt4GHWriterNoDiscard(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	all, err := ioutil.ReadAll(reader)
+	all, err := io.ReadAll(reader)
 	if err != nil {
 		t.Error(err)
 	}
@@ -189,7 +188,7 @@ func TestReencryptionWithDataEditListInCrypt4GHWriterNoDiscard(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	inBytes, err := ioutil.ReadAll(inFile)
+	inBytes, err := io.ReadAll(inFile)
 	if err != nil {
 		t.Error(err)
 	}
@@ -244,7 +243,7 @@ func TestReencryptionWithDataEditListInCrypt4GHReaderNoDiscard(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	all, err := ioutil.ReadAll(reader)
+	all, err := io.ReadAll(reader)
 	if err != nil {
 		t.Error(err)
 	}
@@ -252,7 +251,7 @@ func TestReencryptionWithDataEditListInCrypt4GHReaderNoDiscard(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	inBytes, err := ioutil.ReadAll(inFile)
+	inBytes, err := io.ReadAll(inFile)
 	if err != nil {
 		t.Error(err)
 	}
@@ -315,7 +314,7 @@ func TestReencryptionWithDataEditListAndDiscard(t *testing.T) {
 	if discarded != toDiscard {
 		t.Fail()
 	}
-	all, err := ioutil.ReadAll(reader)
+	all, err := io.ReadAll(reader)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
- deprecate golang versions 1.16 and 1.17 in github actions
- update golang-ci version in github action
- clean go.sum
- refactor code for deprecated `io/ioutil`