### PR TITLE
Bugfix/build release libc linkage

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,18 +8,22 @@ builds:
       - darwin
       - linux
       - windows
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
 
 archives:
-  -
-    replacements:
-      amd64: x86_64
-      386: i386
-
-    name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- tolower .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
 
 changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - "^docs:"
+      - "^test:"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 // The version in the current branch
-var Version = "1.7.1"
+var Version = "1.7.3"
 
 // If this is "" (empty string) then it means that it is a final release.
 // Otherwise, this is a pre-release e.g. "dev", "beta", "rc1", etc.


### PR DESCRIPTION
- fix issue with release that caused:
```
./crypt4gh: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./crypt4gh)
./crypt4gh: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./crypt4gh)
```
- set version to 1.7.3
- update `archives` `name_templates` to new syntax

test result in:  https://github.com/neicnordic/crypt4gh/releases/tag/v1.7.3-alpha

thanks @jbygdell for noticing 