### PR TITLE
Do not panic on unexpected key format

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 // The version in the current branch
-var Version = "1.8.0"
+var Version = "1.8.1"
 
 // If this is "" (empty string) then it means that it is a final release.
 // Otherwise, this is a pre-release e.g. "dev", "beta", "rc1", etc.

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -120,7 +120,7 @@ func ReadPrivateKey(reader io.Reader, passPhrase []byte) (privateKey [chacha20po
 	}
 
 	// Interpreting bytes as Crypt4GH private key bytes (https://crypt4gh.readthedocs.io/en/latest/keys.html)
-	if string(block.Bytes[:7]) == magic {
+	if len(block.Bytes) > 8 && string(block.Bytes[:7]) == magic {
 		return readCrypt4GHPrivateKey(block.Bytes, passPhrase)
 	}
 
@@ -261,6 +261,9 @@ func ReadPublicKey(reader io.Reader) (publicKey [chacha20poly1305.KeySize]byte, 
 		}
 	}
 
+	if len(block.Bytes) < chacha20poly1305.KeySize {
+		return publicKey, fmt.Errorf("Unsupported key file format")
+	}
 	// Interpreting bytes as Crypt4GH public key bytes (X25519)
 	copy(publicKey[:], block.Bytes[len(block.Bytes)-chacha20poly1305.KeySize:])
 

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -95,6 +95,11 @@ func ReadPrivateKey(reader io.Reader, passPhrase []byte) (privateKey [chacha20po
 	// Not OpenSSH private key, assuming OpenSSL private key, trying to figure out type (Ed25519 or X25519)
 	block, _ := pem.Decode(allBytes)
 
+	if block == nil {
+		return [chacha20poly1305.KeySize]byte{}, fmt.Errorf("Read of unrecognized private key format failed; " +
+			"expected PEM encoded key")
+	}
+
 	var openSSLPrivateKey openSSLPrivateKey
 	if _, err = asn1.Unmarshal(block.Bytes, &openSSLPrivateKey); err == nil {
 		// Trying to read OpenSSL Ed25519 private key and convert to X25519 private key
@@ -233,6 +238,12 @@ func ReadPublicKey(reader io.Reader) (publicKey [chacha20poly1305.KeySize]byte, 
 
 	// Not OpenSSH public key, assuming OpenSSL public key
 	block, _ := pem.Decode(allBytes)
+
+	if block == nil {
+		return [chacha20poly1305.KeySize]byte{}, fmt.Errorf("Read of unrecognized public key format failed; " +
+			"expected PEM encoded key")
+	}
+
 	var openSSLPublicKey openSSLPublicKey
 	if _, err = asn1.Unmarshal(block.Bytes, &openSSLPublicKey); err == nil {
 		// Trying to read OpenSSL Ed25519 public key and convert to X25519 public key


### PR DESCRIPTION
We used to panic on non-PEM-encoded keys, don't do that.

Also, some PEM-areas with less data than expected would also cause panics, fixes that as well.