### PR TITLE
Update `README` with enhanced installation instructions for `M1` Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ curl -fsSL https://raw.githubusercontent.com/neicnordic/crypt4gh/master/install.
 
 ### MacOS
 ```
-curl -fsSL https://raw.githubusercontent.com/neicnordic/crypt4gh/master/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/neicnordic/crypt4gh/master/install.sh | sudo sh
 ```
 
 ### Windows


### PR DESCRIPTION
**Description:**
This pull request updates the README file to provide enhanced installation instructions specifically for users with M1 Macs. Given the unique permission requirements of the M1 Mac architecture, particularly when writing to protected directories like `/usr/local/bin`, the existing instructions could lead to a 'Permission Denied' error during installation. The updated instructions offer clear guidance on how to successfully install the software on M1 Macs, ensuring a smoother setup process for users with this hardware.