### PR TITLE
Add support for unencrypted private crypt4gh keys

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 // The version in the current branch
-var Version = "1.9.0"
+var Version = "1.9.1"
 
 // If this is "" (empty string) then it means that it is a final release.
 // Otherwise, this is a pre-release e.g. "dev", "beta", "rc1", etc.

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -46,6 +46,11 @@ ECAwQ=
 -----END OPENSSH PRIVATE KEY-----
 `
 
+const unencryptedCrypt4GH = `-----BEGIN CRYPT4GH PRIVATE KEY-----
+YzRnaC12MQAEbm9uZQAEbm9uZQAgCvMeraG2L8NC9rDji46RXESWcXkoV5JeF0IiJdvzyhQ=
+-----END CRYPT4GH PRIVATE KEY-----
+`
+
 const sshEd25519Pub = `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGShUtbgxD70Gj+alwupjPHpTeIHf/s7pWNfx10VvYHV dmytrot@Dmytros-MacBook-Pro.local
 `
 
@@ -100,6 +105,14 @@ func TestReadKey(t *testing.T) {
 		passPhrase             []byte
 		hash                   string
 	}{
+		{
+			name:                   "unencrypted.sec.pem",
+			content:                unencryptedCrypt4GH,
+			readPrivateKeyFunction: ReadPrivateKey,
+			readPublicKeyFunction:  nil,
+			passPhrase:             nil,
+			hash:                   "0af31eada1b62fc342f6b0e38b8e915c449671792857925e17422225dbf3ca14",
+		},
 		{
 			name:                   "crypt4gh-x25519-enc.sec.pem",
 			content:                crypt4ghX25519Sec,


### PR DESCRIPTION
This fixes support for unencrypted private crypt4gh keys. Support essentially existed but due to a logic error wasn't usable (KDF was checked against a list of actual KDFs, not including `none`, which is used for the unencrypted case) and failed if no match was found.

This moves the unencrypted case up a bit and lets the following code be a little simpler, also adds a testcase for an unencrypted key. 