### PR TITLE
Add convenience function to return the size of an encrypted segment

### DIFF
--- a/model/headers/headers.go
+++ b/model/headers/headers.go
@@ -282,6 +282,7 @@ func EncryptedSegmentSize(header []byte, readerPrivateKey [chacha20poly1305.KeyS
 			return 0, fmt.Errorf("different data encryption methods are not supported")
 		}
 	}
+
 	return firstDataEncryptionParametersHeader.EncryptedSegmentSize, nil
 }
 

--- a/model/headers/headers_test.go
+++ b/model/headers/headers_test.go
@@ -299,3 +299,37 @@ func TestReEncryptedHeader(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestEncryptedSegmentSize(t *testing.T) {
+	inFile, err := os.Open("../../test/sample.txt.enc")
+	if err != nil {
+		t.Errorf("Fileopen failed: %v", err)
+	}
+	readerSecretKey, err := keys.ReadPrivateKey(strings.NewReader(crypt4ghX25519Sec), []byte("password"))
+	if err != nil {
+		t.Errorf("ReadPrivateKey failed: %v", err)
+	}
+
+	header, err := ReadHeader(inFile)
+	if err != nil {
+		t.Errorf("ReadHeader failed: %v", err)
+	}
+
+	size, err := EncryptedSegmentSize(header, readerSecretKey)
+	if err != nil {
+		t.Errorf("EncryptedSegmentSize failed where it should work: %v", err)
+	} else if size != 65564 {
+		t.Errorf("EncryptedSegmentSize returned unexpected size %d (expected 65564)", size)
+	}
+
+	size, err = EncryptedSegmentSize(header, ([32]byte)(make([]byte, 32)))
+	if err == nil {
+		t.Errorf("EncryptedSegmentSize worked where it should fail: %v", err)
+	}
+
+	size, err = EncryptedSegmentSize(make([]byte, 2), readerSecretKey)
+	if err == nil {
+		t.Errorf("EncryptedSegmentSize worked where it should fail: %v", err)
+	}
+
+}

--- a/model/headers/headers_test.go
+++ b/model/headers/headers_test.go
@@ -322,12 +322,12 @@ func TestEncryptedSegmentSize(t *testing.T) {
 		t.Errorf("EncryptedSegmentSize returned unexpected size %d (expected 65564)", size)
 	}
 
-	size, err = EncryptedSegmentSize(header, ([32]byte)(make([]byte, 32)))
+	_, err = EncryptedSegmentSize(header, ([32]byte)(make([]byte, 32)))
 	if err == nil {
 		t.Errorf("EncryptedSegmentSize worked where it should fail: %v", err)
 	}
 
-	size, err = EncryptedSegmentSize(make([]byte, 2), readerSecretKey)
+	_, err = EncryptedSegmentSize(make([]byte, 2), readerSecretKey)
 	if err == nil {
 		t.Errorf("EncryptedSegmentSize worked where it should fail: %v", err)
 	}


### PR DESCRIPTION
Add straight-forward function, given a header/private key that can decrypt it, return the encrypted segment size used in the stream.