### PR TITLE
Add ability to add/replace headers when doing header re-encryption

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 // The version in the current branch
-var Version = "1.9.1"
+var Version = "1.10.0"
 
 // If this is "" (empty string) then it means that it is a final release.
 // Otherwise, this is a pre-release e.g. "dev", "beta", "rc1", etc.

--- a/model/headers/headers_test.go
+++ b/model/headers/headers_test.go
@@ -46,12 +46,12 @@ func TestHeaderMarshallingWithNonce(t *testing.T) {
 
 	writerPrivateKey, err := keys.ReadPrivateKey(strings.NewReader(sshEd25519SecEnc), []byte("123123"))
 	if err != nil {
-		panic(err)
+		t.Errorf("Reading private key from string failed: %v", err)
 	}
 
 	readerPublicKey, err := keys.ReadPublicKey(strings.NewReader(crypt4ghX25519Pub))
 	if err != nil {
-		panic(err)
+		t.Errorf("Reading public key from string failed: %v", err)
 	}
 	var nonce = [12]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
 	magic := [8]byte{}
@@ -104,11 +104,11 @@ func TestNewHeader(t *testing.T) {
 	buffer := bytes.NewBuffer(decodedHeader)
 	readerSecretKey, err := keys.ReadPrivateKey(strings.NewReader(crypt4ghX25519Sec), []byte("password"))
 	if err != nil {
-		panic(err)
+		t.Errorf("Reading private key from string failed: %v", err)
 	}
 	header, err := NewHeader(buffer, readerSecretKey)
 	if err != nil {
-		panic(err)
+		t.Errorf("NewHeader failed unexpectedly: %v", err)
 	}
 	if fmt.Sprintf("%v", header) != "&{[99 114 121 112 116 52 103 104] 1 2 [{[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] 108 0 <nil> {65564 {0} 0 [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]}} {[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] 100 0 <nil> {{1} 3 [1 2 3]}}]}" {
 		t.Fail()
@@ -154,12 +154,12 @@ func TestHeaderMarshallingWithoutNonce(t *testing.T) {
 
 	writerPrivateKey, err := keys.ReadPrivateKey(strings.NewReader(sshEd25519SecEnc), []byte("123123"))
 	if err != nil {
-		panic(err)
+		t.Errorf("Reading private key from string failed: %v", err)
 	}
 
 	readerPublicKey, err := keys.ReadPublicKey(strings.NewReader(crypt4ghX25519Pub))
 	if err != nil {
-		panic(err)
+		t.Errorf("Reading public key from string failed: %v", err)
 	}
 	magic := [8]byte{}
 	copy(magic[:], MagicNumber)
@@ -280,7 +280,7 @@ func TestReEncryptedHeaderReplacementAndAddition(t *testing.T) {
 
 	newHeader, err := ReEncryptHeader(oldHeader, readerSecretKey, newReaderPublicKeyList, del, anotherDel)
 	if err != nil {
-		panic(err)
+		t.Errorf("Reencrypting header gave unexpected failure: %v", err)
 	}
 	t.Logf("Header: %v", newHeader)
 
@@ -297,7 +297,7 @@ func TestReEncryptedHeaderReplacementAndAddition(t *testing.T) {
 	buffer := bytes.NewBuffer(newHeader)
 	header, err := NewHeader(buffer, newReaderSecretKey)
 	if err != nil {
-		panic(err)
+		t.Errorf("NewHeader gave unexpected failure: %v", err)
 	}
 
 	newDel, ok := header.HeaderPackets[1].EncryptedHeaderPacket.(DataEditListHeaderPacket)
@@ -335,7 +335,7 @@ func TestReEncryptedHeaderReplacementAndAddition(t *testing.T) {
 	buffer = bytes.NewBuffer(newerHeader)
 	header, err = NewHeader(buffer, readerSecretKey)
 	if err != nil {
-		panic(err)
+		t.Errorf("NewHeader gave unexpected failure: %v", err)
 	}
 
 	newDel, ok = header.HeaderPackets[1].EncryptedHeaderPacket.(DataEditListHeaderPacket)
@@ -373,7 +373,7 @@ func TestReEncryptedHeader(t *testing.T) {
 
 	newHeader, err := ReEncryptHeader(oldHeader, readerSecretKey, newReaderPublicKeyList)
 	if err != nil {
-		panic(err)
+		t.Errorf("ReEncryptHeader gave unexpected failure: %v", err)
 	}
 
 	// if the headers are similar then that is not ok
@@ -389,7 +389,7 @@ func TestReEncryptedHeader(t *testing.T) {
 	buffer := bytes.NewBuffer(newHeader)
 	header, err := NewHeader(buffer, newReaderSecretKey)
 	if err != nil {
-		panic(err)
+		t.Errorf("NewHeader gave unexpected failure: %v", err)
 	}
 	if fmt.Sprintf("%v", header) != "&{[99 114 121 112 116 52 103 104] 1 1 [{[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] 108 0 <nil> {65564 {0} 0 [111 194 187 210 222 31 213 211 134 204 70 51 56 197 11 150 188 141 28 253 188 188 76 243 7 143 50 179 45 172 135 132]}}]}" {
 		t.Error(header)
@@ -428,5 +428,4 @@ func TestEncryptedSegmentSize(t *testing.T) {
 	if err == nil {
 		t.Errorf("EncryptedSegmentSize worked where it should fail: %v", err)
 	}
-
 }

--- a/model/headers/headers_test.go
+++ b/model/headers/headers_test.go
@@ -339,12 +339,10 @@ func TestReEncryptedHeaderReplacementAndAddition(t *testing.T) {
 	}
 
 	newDel, ok = header.HeaderPackets[1].EncryptedHeaderPacket.(DataEditListHeaderPacket)
-
 	if !ok {
 		t.Logf("Not DEL as expected: %v", header.HeaderPackets[1].EncryptedHeaderPacket)
 		t.Fail()
 	}
-
 	if newDel.NumberLengths != 4 || !reflect.DeepEqual(newDel.Lengths, []uint64{0, 5, 10, 15}) {
 		t.Logf("Unexpected length (%d vs 4) or content in copied DEL: %v vs {0, 5, 10, 15}", newDel.NumberLengths, newDel.Lengths)
 		t.Fail()

--- a/model/headers/headers_test.go
+++ b/model/headers/headers_test.go
@@ -315,6 +315,9 @@ func TestReEncryptedHeaderReplacementAndAddition(t *testing.T) {
 	// Test DEL copying when reencryption, i.e. when the DEL is not replaced. Encrypt back for the original recipient
 
 	newRecipientSecretKey, err := keys.ReadPrivateKey(strings.NewReader(newRecipientSec), []byte("password"))
+	if err != nil {
+		t.Errorf("Failed creating new recipient secret key: %v", err)
+	}
 
 	newerReaderPublicKey, err := keys.ReadPublicKey(strings.NewReader(crypt4ghX25519Pub))
 	if err != nil {

--- a/streaming/streaming_test.go
+++ b/streaming/streaming_test.go
@@ -1426,7 +1426,7 @@ func TestReEncryptedHeaderReplacementAndAdditionFileRead(t *testing.T) {
 
 	newHeader, err := headers.ReEncryptHeader(oldHeader, readerSecretKey, newReaderPublicKeyList, del)
 	if err != nil {
-		panic(err)
+		t.Errorf("NewHeader failed unexpectedly: %v", err)
 	}
 	t.Logf("Header: %v", newHeader)
 
@@ -1482,5 +1482,4 @@ func TestReEncryptedHeaderReplacementAndAdditionFileRead(t *testing.T) {
 		t.Logf("Expected: %v", sourceBytes[:100])
 		t.Errorf("Unexpected data after re-encryption and del added")
 	}
-
 }


### PR DESCRIPTION
Allow passing of zero or more EncryptedHeaderPacket that will be added to the reencrypted header by ReEncryptHeader. If a packet of the same type exists already it will be replaced.