### PR TITLE
Add some sanity limits on header values

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 // The version in the current branch
-var Version = "1.10.0"
+var Version = "1.11.0"
 
 // If this is "" (empty string) then it means that it is a final release.
 // Otherwise, this is a pre-release e.g. "dev", "beta", "rc1", etc.

--- a/model/headers/headers_test.go
+++ b/model/headers/headers_test.go
@@ -429,3 +429,37 @@ func TestEncryptedSegmentSize(t *testing.T) {
 		t.Errorf("EncryptedSegmentSize worked where it should fail: %v", err)
 	}
 }
+
+func TestHeaderLimits(t *testing.T) {
+
+	// Test ReadHeader packet count limit
+	b := bytes.NewBuffer([]byte("crypt4gh\x01\x00\x00\x00\x01\x00\x00\x11"))
+	_, err := ReadHeader(b)
+	if err == nil || !strings.Contains(err.Error(), "exceeds maximum") || !strings.Contains(err.Error(), "count") {
+		t.Errorf("Didn't see expected error from ReadHeader, expected header packet count, got %v", err)
+	}
+
+	// Test ReadHeader packet length limit
+	b = bytes.NewBuffer([]byte("crypt4gh\x01\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x01\x00\x00"))
+	_, err = ReadHeader(b)
+
+	if err == nil || !strings.Contains(err.Error(), "exceeds maximum") || !strings.Contains(err.Error(), "length") {
+		t.Errorf("Didn't see expected error from ReadHeader, expected header packet count, got %v", err)
+	}
+
+	// Test NewHeader packet count limit
+	var key [chacha20poly1305.KeySize]byte
+	b = bytes.NewBuffer([]byte("crypt4gh\x01\x00\x00\x00\x01\x00\x00\x11"))
+	_, err = NewHeader(b, key)
+	if err == nil || !strings.Contains(err.Error(), "exceeds maximum") || !strings.Contains(err.Error(), "count") {
+		t.Errorf("Didn't see expected error from ReadHeader, expected header packet count, got %v", err)
+	}
+
+	// Test NewHeader packet length limit
+	b = bytes.NewBuffer([]byte("crypt4gh\x01\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x01\x00\x00"))
+	_, err = NewHeader(b, key)
+	if err == nil || !strings.Contains(err.Error(), "exceeds maximum") || !strings.Contains(err.Error(), "length") {
+		t.Errorf("Didn't see expected error from ReadHeader, expected header packet count, got %v", err)
+	}
+
+}


### PR DESCRIPTION
This adds some sanity limits when reading header packets without which one could possibly executedenial-of-service attacks through resource consumption.

I normally do not like libraries arbitrarily restricting otherewise valid usages, but think these limits are permissive enough that it should not be a problem. If it's still considered too restrictive, one can implement the ability to pass flags through varargs, meaning the signature used in calls could remain the same so no code would need to be rewritten unless they want to pass such flags). I currently can't think of any use case that would need that, though.