### PR TITLE
[linter] Exclude `G115 - integer overflow`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,4 +21,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6.1.0
         with:
           version: latest
-          args: -E bodyclose,gocritic,gofmt,gosec,govet,nestif,nlreturn,revive,rowserrcheck --exclude G401,G501,G107
+          args: -E bodyclose,gocritic,gofmt,gosec,govet,nestif,nlreturn,revive,rowserrcheck --exclude G401,G501,G107,G115


### PR DESCRIPTION
When the language has no solution to check the overflow in time of convert, so linter shouldn't check the overflow.