### PR TITLE
Group updates so we get a single release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@ version: 2
 updates:
   - package-ecosystem: gomod
     directory: "/"
+    groups:
+      all-modules:
+        patterns:
+          - "*"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10


### PR DESCRIPTION
Group dependabot updates so we get a single PR and as such a single patch release going forward.