### PR TITLE
Change PBKDF2 hash from SHA512 to SHA256 (according to specification)

### DIFF
--- a/kdf/kdf.go
+++ b/kdf/kdf.go
@@ -2,7 +2,7 @@
 package kdf
 
 import (
-	"crypto/sha512"
+	"crypto/sha256"
 
 	// package is old but corresponds to "golang.org/x/crypto/ssh/internal/bcrypt_pbkdf"
 	"github.com/dchest/bcrypt_pbkdf"
@@ -15,7 +15,7 @@ import (
 var KDFS = map[string]KDF{
 	"scrypt":             sCrypt{},
 	"bcrypt":             bCrypt{},
-	"pbkdf2_hmac_sha256": pbkdf2sha512{},
+	"pbkdf2_hmac_sha256": pbkdf2sha256{},
 }
 
 // KDF interface holding "Derive" method.
@@ -37,9 +37,9 @@ func (bCrypt) Derive(rounds int, password, salt []byte) (derivedKey []byte, err 
 	return bcrypt_pbkdf.Key(password, salt, rounds, chacha20poly1305.KeySize)
 }
 
-type pbkdf2sha512 struct {
+type pbkdf2sha256 struct {
 }
 
-func (pbkdf2sha512) Derive(rounds int, password, salt []byte) (derivedKey []byte, err error) {
-	return pbkdf2.Key(password, salt, rounds, chacha20poly1305.KeySize, sha512.New), nil
+func (pbkdf2sha256) Derive(rounds int, password, salt []byte) (derivedKey []byte, err error) {
+	return pbkdf2.Key(password, salt, rounds, chacha20poly1305.KeySize, sha256.New), nil
 }

--- a/kdf/kdf_test.go
+++ b/kdf/kdf_test.go
@@ -20,7 +20,7 @@ func TestKDF(t *testing.T) {
 		},
 		{
 			name: "pbkdf2_hmac_sha256",
-			hash: "72bf7d2b4d1f18c97a333e3a89e7f22dc9771b968ddcbc1a494fbbf507059b13",
+			hash: "dd3352defb9aa734875f7a32b60e4bcf9e3671216d6e0c39f135f0297bf8e121",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
I have been looking more deeply into the [Java version of Crypt4GH](https://github.com/ELIXIR-NO/FEGA-Norway/tree/main/lib/crypt4gh) created by Dmytro Titov (@dtitov) many years ago, 
and especially the [KDF functions](https://crypt4gh.readthedocs.io/en/latest/keys.html) that stretch the password used to encrypt the private key file.

I compared the Java version to the [Python implementation](https://github.com/EGA-archive/crypt4gh) and this [Go implementation](https://github.com/neicnordic/crypt4gh) to see if the KDFs produce the same hash values and verify that private key files created with the different versions are compatible with each other.
The good news is that all three versions produce the same hash for SCrypt, which is the preferred and default KDF. For the BCrypt alternative, the Python and Go implementations are compatible, but the Java version is not. I am looking into that.

For PBKDF2, the Java and Python versions are compatible but the Go version is not. PBKDF2 combines the input with a salt using a hash function and repeats this process multiple times. And from the [Crypt4GH documentation](https://crypt4gh.readthedocs.io/en/latest/keys.html), it seems clear that PBKDF2 should use SHA256 as its hash function. It is even part of the name for the KDF: `pbkdf2_hmac_sha256`.

But for some reason, the Go implementation is using [SHA512](https://github.com/neicnordic/crypt4gh/blob/35584b2ad0e6b1eae100398d315607e655a65f4e/kdf/kdf.go#L44C70-L44C80), even if it still retains the KDF name [pbkdf2_hmac_sha256](https://github.com/neicnordic/crypt4gh/blob/35584b2ad0e6b1eae100398d315607e655a65f4e/kdf/kdf.go#L18).
I don't know the reason for this. Perhaps Dmytro decided to use SHA512 because it is more secure, but this should not really matter much anyway, since PBKDF2 should not really be used in the first place, and it is only an alternative in case the first two options, SCrypt and BCrypt, are not available.

My PR changes the hash function back to SHA256 (which is the correct choice according to the Crypt4GH specification) and makes it compatible with the other two implementations of Crypt4GH.

The new hash value in the [kdf_test.go](https://github.com/kjetilkl/crypt4gh_go/blob/6d7085f32a553b375d659b4f93609bdefd40f733/kdf/kdf_test.go#L23) file is the one that is returned by the Python implementation using SHA256.